### PR TITLE
solving syntax error for reserved words of SQL #8

### DIFF
--- a/pypgsync/util/create.py
+++ b/pypgsync/util/create.py
@@ -22,7 +22,7 @@ def insert_records(con: psycopg.Connection, table_name: str, records: List[Dict]
     for record in records:
         for column_name in record.keys():
             columns_names.add(column_name)
-    columns_names = list(columns_names)
+    columns_names = [f"{col}" for col in list(columns_names)]
 
     columns_names_str = ",".join(columns_names)
     values_str = ",".join(["%s" for _ in range(len(columns_names))])

--- a/pypgsync/util/query.py
+++ b/pypgsync/util/query.py
@@ -45,7 +45,7 @@ def get_table_column_names(cur: psycopg.Cursor, table_name: str) -> List[str]:
     """For a given table, return all column names in the database"""
     sql = f"""SELECT * FROM {table_name} LIMIT 1;"""
     cur.execute(sql)
-    column_names = [f'"{desc[0]}"' if not desc[0] == "id" else desc[0] for desc in cur.description]
+    column_names = [desc[0] for desc in cur.description]
     return column_names
 
 

--- a/pypgsync/util/query.py
+++ b/pypgsync/util/query.py
@@ -45,7 +45,7 @@ def get_table_column_names(cur: psycopg.Cursor, table_name: str) -> List[str]:
     """For a given table, return all column names in the database"""
     sql = f"""SELECT * FROM {table_name} LIMIT 1;"""
     cur.execute(sql)
-    column_names = [desc[0] for desc in cur.description]
+    column_names = [f'"{desc[0]}"' if not desc[0] == "id" else desc[0] for desc in cur.description]
     return column_names
 
 


### PR DESCRIPTION
Solving #8 by puting all column names in the double quotation marks, except the id column, as it be auto fetched by the argument (primary_key) of method sync_by_primary_key()